### PR TITLE
Allow phpunit to be tested within the directory

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,10 @@
         "zendframework/zend-http": ">=2.0.0",
         "zendframework/zend-uri": ">=2.0.0"
     },
+    "require-dev":
+    {
+        "phpunit/phpunit": "3.7.*"
+    },
     "extra": {
         "branch-alias": {
             "dev-master": "2.0-dev"


### PR DESCRIPTION
On laravel this will make for easy testing of all livedocx functionality as you can just cd into the vendor/zendframework/ ZendService_LiveDocx folder and run vendor/bin/phpunit
